### PR TITLE
Added from_scipy_sparse_matrix function

### DIFF
--- a/jraph/_src/utils.py
+++ b/jraph/_src/utils.py
@@ -1138,19 +1138,16 @@ def sparse_matrix_to_graphs_tuple(
   Returns:
     A `jraph.GraphsTuple` graph based on the sparse matrix.
   """
-  n_edge = np.asarray([np.sum(values)])
-  repeated_senders = []
-  repeated_receivers = []
-  for idx, (sender_idx,
-            receiver_idx) in enumerate(zip(senders, receivers)):
-    num_edges = values[idx]
-    repeated_senders += [sender_idx for _ in range(num_edges)]
-    repeated_receivers += [receiver_idx for _ in range(num_edges)]
+  # To capture graph with no edges, otherwise np.repeat will raise an error.
+  values = np.array([0]) if values.size == 0 else values
+  n_edge = np.array([np.sum(values)])
+  senders = np.repeat(senders, values)
+  receivers = np.repeat(receivers, values)
   return gn_graph.GraphsTuple(
     nodes=None,
     edges=None,
-    receivers=np.asarray(repeated_receivers),
-    senders=np.asarray(repeated_senders),
+    receivers=receivers,
+    senders=senders,
     globals=None,
     n_node=n_node,
     n_edge=n_edge)

--- a/jraph/_src/utils.py
+++ b/jraph/_src/utils.py
@@ -1123,18 +1123,17 @@ def with_zero_out_padding_outputs(
 
   return wrapper
 
-  
 def sparse_matrix_to_graphs_tuple(
     senders: jnp.ndarray, receivers: jnp.ndarray,
     values: jnp.ndarray, n_node: jnp.ndarray) -> gn_graph.GraphsTuple:
   """Creates a `jraph.GraphsTuple` from a sparse matrix in COO format.
-  
+
   Args:
     senders: The row indices of the matrix.
     receivers: The column indices of the matrix.
     values: The values of the matrix.
     n_node: The number of nodes in the graph defined by the sparse matrix.
-    
+
   Returns:
     A `jraph.GraphsTuple` graph based on the sparse matrix.
   """

--- a/jraph/_src/utils.py
+++ b/jraph/_src/utils.py
@@ -22,7 +22,6 @@ import jax.numpy as jnp
 import jax.tree_util as tree
 from jraph._src import graph as gn_graph
 import numpy as np
-import scipy.sparse
 
 # As of 04/2020 pytype doesn't support recursive types.
 # pytype: disable=not-supported-yet

--- a/jraph/_src/utils.py
+++ b/jraph/_src/utils.py
@@ -1125,8 +1125,8 @@ def with_zero_out_padding_outputs(
 
   
 def sparse_matrix_to_graphs_tuple(
-  senders: jnp.ndarray, receivers: jnp.ndarray,
-  values: jnp.ndarray, n_node: jnp.ndarray) -> gn_graph.GraphsTuple:
+    senders: jnp.ndarray, receivers: jnp.ndarray,
+    values: jnp.ndarray, n_node: jnp.ndarray) -> gn_graph.GraphsTuple:
   """Creates a `jraph.GraphsTuple` from a sparse matrix in COO format.
   
   Args:
@@ -1144,10 +1144,10 @@ def sparse_matrix_to_graphs_tuple(
   senders = np.repeat(senders, values)
   receivers = np.repeat(receivers, values)
   return gn_graph.GraphsTuple(
-    nodes=None,
-    edges=None,
-    receivers=receivers,
-    senders=senders,
-    globals=None,
-    n_node=n_node,
-    n_edge=n_edge)
+      nodes=None,
+      edges=None,
+      receivers=receivers,
+      senders=senders,
+      globals=None,
+      n_node=n_node,
+      n_edge=n_edge)

--- a/jraph/_src/utils.py
+++ b/jraph/_src/utils.py
@@ -1123,6 +1123,7 @@ def with_zero_out_padding_outputs(
 
   return wrapper
 
+
 def sparse_matrix_to_graphs_tuple(
     senders: jnp.ndarray, receivers: jnp.ndarray,
     values: jnp.ndarray, n_node: jnp.ndarray) -> gn_graph.GraphsTuple:

--- a/jraph/_src/utils.py
+++ b/jraph/_src/utils.py
@@ -1125,23 +1125,24 @@ def with_zero_out_padding_outputs(
   return wrapper
 
 
-def from_scipy_sparse_matrix(A: scipy.sparse.spmatrix):
+def sparse_matrix_to_graphs_tuple(sparse_matrix: scipy.sparse.spmatrix) -> gn_graph.GraphsTuple:
   """Creates a `jraph.GraphsTuple` from a scipy sparse matrix.
   
   Args:
-    A: A SciPy sparse matrix.
+    sparse_matrix: A SciPy sparse matrix.
     
   Returns:
-    A `jraph.GraphsTuple` graph based on the scipy sparse matrix `A`.
+    A `jraph.GraphsTuple` graph based on the scipy sparse matrix `sparse_matrix`.
   """
-  A = A.tocoo()
-  n_node = jnp.asarray([A.shape[1]])
-  n_edge = jnp.asarray([jnp.sum(A.data)])
+  sparse_matrix = sparse_matrix.tocoo()
+  n_node = jnp.asarray([sparse_matrix.shape[1]])
+  n_edge = jnp.asarray([jnp.sum(sparse_matrix.data)])
   
   senders = []
   receivers = []
-  for idx, (sender_idx, receiver_idx) in enumerate(zip(A.row, A.col)):
-    num_edges = A.data[idx]
+  for idx, (sender_idx,
+            receiver_idx) in enumerate(zip(sparse_matrix.row, sparse_matrix.col)):
+    num_edges = sparse_matrix.data[idx]
     senders += [sender_idx for _ in range(num_edges)]
     receivers += [receiver_idx for _ in range(num_edges)]
   

--- a/jraph/_src/utils_test.py
+++ b/jraph/_src/utils_test.py
@@ -168,8 +168,7 @@ def _get_list_and_batched_graph():
 
 
 def _get_list_matrix():
-  """Returns a list of adjacency matrices, its sparse version
-  and expected `GraphsTuple` corresponding to them.
+  """Returns a list of adjacency matrices, and its sparse and graph versions.
 
   This test-case includes the following corner-cases:
     - single node,
@@ -186,7 +185,7 @@ def _get_list_matrix():
       np.array([[0, 0], [1, 0]]),
   ]
   # Sparse version of the above adjacency matrix.
-  sparse_COO_matrices = [
+  sparse_coo_matrices = [
       # (row, column, values, n_node)
       (np.array([0]), np.array([0]), np.array([2]), np.array([1])),
       (np.array([0, 0, 1, 2, 2]), np.array([0, 1, 2, 0, 1]),
@@ -227,7 +226,7 @@ def _get_list_matrix():
           senders=jnp.array([1]),
           receivers=jnp.array([0])),
   ]
-  return adj_matrices, sparse_COO_matrices, expected_graphs
+  return adj_matrices, sparse_coo_matrices, expected_graphs
 
 
 class GraphTest(parameterized.TestCase):
@@ -1127,8 +1126,8 @@ class AdjacencyMatrixTest(parameterized.TestCase):
     for (sparse_matrix,
          expected_graph) in zip(sparse_adj_matrices, expected_graphs):
       senders, receivers, values, n_node = sparse_matrix
-      from_sparse_graph = utils.\
-          sparse_matrix_to_graphs_tuple(senders, receivers, values, n_node)
+      from_sparse_graph = utils.sparse_matrix_to_graphs_tuple(
+          senders, receivers, values, n_node)
       jax.tree_util.tree_map(np.testing.assert_allclose,
                              from_sparse_graph, expected_graph)
 

--- a/jraph/_src/utils_test.py
+++ b/jraph/_src/utils_test.py
@@ -187,13 +187,13 @@ def _get_list_matrix():
   ]
   # Sparse version of the above adjacency matrix.
   sparse_COO_matrices = [
-    # (row, column, values, n_node)
-    (np.array([0]), np.array([0]), np.array([2]), np.array([1])),
-    (np.array([0, 0, 1, 2, 2]), np.array([0, 1, 2, 0, 1]), 
-     np.array([1, 1, 1, 1, 1]), np.array(3)),
-    (np.array([]), np.array([]), np.array([]), np.array(1)),
-    (np.array([]), np.array([]), np.array([]), np.array(0)),
-    (np.array([1]), np.array([0]), np.array([1]), np.array(2)),
+      # (row, column, values, n_node)
+      (np.array([0]), np.array([0]), np.array([2]), np.array([1])),
+      (np.array([0, 0, 1, 2, 2]), np.array([0, 1, 2, 0, 1]),
+       np.array([1, 1, 1, 1, 1]), np.array(3)),
+      (np.array([]), np.array([]), np.array([]), np.array(1)),
+      (np.array([]), np.array([]), np.array([]), np.array(0)),
+      (np.array([1]), np.array([0]), np.array([1]), np.array(2)),
   ]
   expected_graphs = [
       graph.GraphsTuple(
@@ -225,7 +225,7 @@ def _get_list_matrix():
           n_edge=jnp.array([1]),
           nodes=None, edges=None, globals=None,
           senders=jnp.array([1]),
-          receivers=jnp.array([0])),     
+          receivers=jnp.array([0])),
   ]
   return adj_matrices, sparse_COO_matrices, expected_graphs
 
@@ -1119,7 +1119,7 @@ class ZeroOutTest(parameterized.TestCase):
 
 
 class AdjacencyMatrixTest(parameterized.TestCase):
-  
+
   def test_sparse_matrix_to_graphs_tuple(self):
     """Tests sparse COO matrix is correctly converted to a GraphsTuple."""
     _, sparse_adj_matrices, expected_graphs = _get_list_matrix()
@@ -1127,9 +1127,9 @@ class AdjacencyMatrixTest(parameterized.TestCase):
          expected_graph) in zip(sparse_adj_matrices, expected_graphs):
       senders, receivers, values, n_node = sparse_matrix
       from_sparse_graph = utils.\
-        sparse_matrix_to_graphs_tuple(senders, receivers, values, n_node)
-      jax.tree_util.tree_map(np.testing.assert_allclose, 
-                            from_sparse_graph, expected_graph)
+          sparse_matrix_to_graphs_tuple(senders, receivers, values, n_node)
+      jax.tree_util.tree_map(np.testing.assert_allclose,
+                             from_sparse_graph, expected_graph)
 
 
 if __name__ == '__main__':

--- a/jraph/_src/utils_test.py
+++ b/jraph/_src/utils_test.py
@@ -25,7 +25,6 @@ import jax.tree_util as tree
 from jraph._src import graph
 from jraph._src import utils
 import numpy as np
-import scipy.sparse
 
 
 def _get_random_graph(max_n_graph=10,

--- a/jraph/_src/utils_test.py
+++ b/jraph/_src/utils_test.py
@@ -1116,7 +1116,7 @@ class AdjacencyMatrixTest(parameterized.TestCase):
     """Tests adjacency matrix is correctly converted to a GraphsTuple."""
     _, sparse_adj_matrices, expected_graphs = _get_list_matrix()
     for A, expected_graph in zip(sparse_adj_matrices, expected_graphs):
-      from_sparse_graph = utils.from_scipy_sparse_matrix(A)
+      from_sparse_graph = utils.sparse_matrix_to_graphs_tuple(A)
       jax.tree_util.tree_map(np.testing.assert_allclose, 
                             from_sparse_graph, expected_graph)
 


### PR DESCRIPTION
I've added a simple function (together with tests) to convert a scipy sparse matrix into a jraph GraphsTuple as per mentioned in issue #36. Let me know if anything need changes :)

Some future work I'm considering includes making a to_scipy_sparse_matrix function and intermediate functions for NetworkX.