### PR TITLE
fix hamilton graph network example

### DIFF
--- a/jraph/examples/hamiltonian_graph_network.py
+++ b/jraph/examples/hamiltonian_graph_network.py
@@ -199,7 +199,8 @@ def set_system_state(
     position: np.ndarray,
     momentum: np.ndarray) -> jraph.GraphsTuple:
   """Sets the non-static parameters of the graph (momentum, position)."""
-  nodes = static_graph.nodes.copy(position=position, momentum=momentum)
+  nodes = static_graph.nodes.set("position", position)
+  nodes = nodes.set("momentum", momentum)
   return static_graph._replace(nodes=nodes)
 
 


### PR DESCRIPTION
Without this fix I got the following error trace:

```
  File "jraph/examples/hamiltonian_graph_network.py", line 239, in hamiltonian_from_state_fn
    graph = set_system_state(static_graph, position, momentum)
  File "jraph/examples/hamiltonian_graph_network.py", line 202, in set_system_state
    nodes = static_graph.nodes.copy(position=position, momentum=momentum)
jax._src.traceback_util.UnfilteredStackTrace: TypeError: frozendict.copy() got an unexpected keyword argument 'position'
```